### PR TITLE
Fix sorting for arrays of strings and add test cases

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,20 +1,20 @@
 function sortData(data, order) {
-    if (order !== 'asc' && order !== 'desc') {
-      throw new Error('Invalid sort order. Use "asc" or "desc".');
-    }
-  
-    const sortedData = data.slice();
-  
-    sortedData.sort((a, b) => {
-      if (order === 'asc') {
-        return a - b;
-      } else {
-        return b - a;
-      }
-    });
-  
-    return sortedData;
+  if (order !== "asc" && order !== "desc") {
+    throw new Error('Invalid sort order. Use "asc" or "desc".')
   }
-  
-  module.exports = sortData;
-  
+
+  const sortedData = data.slice()
+
+  sortedData.sort((a, b) => {
+    const isAscending = order === "asc"
+    if (typeof a === "string" && typeof b === "string") {
+      return isAscending ? a.localeCompare(b) : b.localeCompare(a)
+    } else {
+      return isAscending ? a - b : b - a
+    }
+  })
+
+  return sortedData
+}
+
+module.exports = sortData

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "order-sorter",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "order-sorter",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "jest": "^29.7.0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,18 +1,30 @@
-const sortData = require('../lib/index');
+const sortData = require("../lib/index")
 
-describe('sortData', () => {
-  test('sorts data in ascending order', () => {
-    const data = [3, 1, 4, 1, 5, 9, 2, 6, 5];
-    expect(sortData(data, 'asc')).toEqual([1, 1, 2, 3, 4, 5, 5, 6, 9]);
-  });
+describe("sortData", () => {
+  test("sorts data in ascending order", () => {
+    const data = [3, 1, 4, 1, 5, 9, 2, 6, 5]
+    expect(sortData(data, "asc")).toEqual([1, 1, 2, 3, 4, 5, 5, 6, 9])
+  })
 
-  test('sorts data in descending order', () => {
-    const data = [3, 1, 4, 1, 5, 9, 2, 6, 5];
-    expect(sortData(data, 'desc')).toEqual([9, 6, 5, 5, 4, 3, 2, 1, 1]);
-  });
+  test("sorts data in descending order", () => {
+    const data = [3, 1, 4, 1, 5, 9, 2, 6, 5]
+    expect(sortData(data, "desc")).toEqual([9, 6, 5, 5, 4, 3, 2, 1, 1])
+  })
 
-  test('throws error for invalid sort order', () => {
-    const data = [3, 1, 4];
-    expect(() => sortData(data, 'invalid')).toThrow('Invalid sort order. Use "asc" or "desc".');
-  });
-});
+  test("sorts data in ascending order", () => {
+    const data = ["apple", "cat", "banana", "app"]
+    expect(sortData(data, "asc")).toEqual(["app", "apple", "banana", "cat"])
+  })
+
+  test("sorts data in descending order", () => {
+    const data = ["apple", "cat", "banana", "app"]
+    expect(sortData(data, "desc")).toEqual(["cat", "banana", "apple", "app"])
+  })
+
+  test("throws error for invalid sort order", () => {
+    const data = [3, 1, 4]
+    expect(() => sortData(data, "invalid")).toThrow(
+      'Invalid sort order. Use "asc" or "desc".'
+    )
+  })
+})


### PR DESCRIPTION
Issue with the sortData function's inability to correctly sort arrays of strings. Additionally, it introduces new test cases to ensure the sorting functionality works as expected for both ascending and descending orders with string arrays.

Changes:

1. Modified the sortData function:
   - Added a type check in the comparison function to handle both numeric and string values.
   - For string values, the comparison function now uses the localeCompare method for lexicographic (alphabetical) sorting.
   - For numeric values, the existing numeric subtraction comparison is retained.

2. Added new test cases:
   - Test case for sorting an array of strings in ascending order.
   - Test case for sorting an array of strings in descending order.
   - Both test cases assert the expected sorted output using Jest's expect and toEqual matchers.
   
   
<img width="481" alt="Screenshot 2024-05-02 at 6 50 33 PM" src="https://github.com/gowtham0612/order-sorter/assets/92677078/b332fd25-5316-474a-bb4b-3e99883df608">

   